### PR TITLE
add browserrouter to queries test  case

### DIFF
--- a/src/tests/exam/Routes/Queries.spec.js
+++ b/src/tests/exam/Routes/Queries.spec.js
@@ -20,7 +20,11 @@ describe(" render Queries component ", () => {
   );
   test("calls api.get with correct URL", () => {
     const mockApiGet = jest.spyOn(api, "get");
-    render(<Queries />);
+    render(
+      <BrowserRouter>
+        <Queries />
+      </BrowserRouter>
+    );
     expect(mockApiGet).toHaveBeenCalledWith("/consulta");
   });
 });


### PR DESCRIPTION
[🧪](https://emojipedia.org/pt/tubo-de-ensaio/) - Test [add browserrouter to queries test case](https://github.com/freibergerss/checkpoint-frontend/commit/60fea5fa1808cee74e053f22f3730fea63d3a3a9)